### PR TITLE
Fix bug in zotra-download-attachment-from-url

### DIFF
--- a/zotra.el
+++ b/zotra.el
@@ -393,7 +393,7 @@ If `zotra-download-attachment-default-directory' is also nil, prompt for the dow
          (pdf (expand-file-name
                (completing-read
                 "Rename attachment to: " nil nil nil
-                (last (split-string attachment "/" t)))
+                (car (last (split-string attachment "/" t))))
                download-dir)))
     (mkdir (file-name-directory pdf) t)
     (url-copy-file attachment pdf 1)
@@ -423,7 +423,7 @@ If `zotra-download-attachment-default-directory' is also nil, prompt for the dow
          (pdf (expand-file-name
                (completing-read
                 "Rename attachment to: " nil nil nil
-                (last (split-string attachment "/" t)))
+                (car (last (split-string attachment "/" t))))
                download-dir)))
     (mkdir (file-name-directory pdf) t)
     (url-copy-file attachment pdf 1)


### PR DESCRIPTION
`last` returns a list which causes `completing-read` to throw a wrong-type-argument errror. Same in 
zotra-download-attachment-from-search.