### PR TITLE
add link to instructions for setting up org-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ See `zotra` customization group for a complete list of options and their descrip
 
 ### Using zotra with a browser and org-protocol
 
-First you need to set up [org-protocol](https://orgmode.org/worg/org-contrib/org-protocol.html).
+	First you need to set up [org-protocol](https://orgmode.org/worg/org-contrib/org-protocol.html). [This section](https://www.orgroam.com/manual.html#Installation-_00281_0029) of the `org-roam` manual describes how to set it up on Linux, macOS, and Windows.
+
 Then make a bookmark in your browser with the following url:
 ```
 javascript:location.href=('org-protocol://zotra?url='+ encodeURIComponent(location.href)+'&bibfile='+encodeURIComponent('/path/to/bibfile.bib')+'&format=my-save-format').replace(/'/gi,"%27")


### PR DESCRIPTION
org-protocol can be a challenge to set up. These instructions will likely help some users.